### PR TITLE
Support for passing settings to lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 
 ![demo-syntax-jsonnet](./static/demo-syntax-macos-light.png)
 
+## Settings
+
+The [jsonnet-language-server][] settings can be changed in the `lsp` section of your settings.json.
+
+```
+{
+  "lsp": {
+    "jsonnet-language-server": {
+      "settings": {
+        "log_level": "info",
+        "resolve_paths_with_tanka": true
+      }
+    }
+  }
+}
+```
+
 ## Related Projects
 
 - [tree-sitter-jsonnet](https://github.com/sourcegraph/tree-sitter-jsonnet)
@@ -11,3 +28,4 @@
 
 [1]: https://jsonnet.org/
 [2]: https://zed.dev/
+[jsonnet-language-server]: https://github.com/grafana/jsonnet-language-server

--- a/src/jsonnet.rs
+++ b/src/jsonnet.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use zed::LanguageServerId;
-use zed_extension_api::{self as zed, Result};
+use zed_extension_api::{self as zed, serde_json, settings::LspSettings, Result};
 
 const LSP_GITHUB_REPO: &str = "grafana/jsonnet-language-server";
 
@@ -113,6 +113,30 @@ impl zed::Extension for JsonnetExtension {
             args: vec!["--log-level".to_string(), "info".to_string()],
             env: Default::default(),
         })
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+        Ok(Some(settings))
     }
 }
 


### PR DESCRIPTION
Closes #1 

This one allows passing custom configuration to the lsp:

```
{
  "lsp": {
    "jsonnet-language-server": {
      "settings": {
        "jpath": ["a/b"],
        "resolve_paths_with_tanka": true
      }
    }
  }
}
```