### PR TITLE
add support for [] {} () brackets, allowing jumping in vim mode with %

### DIFF
--- a/languages/jsonnet/brackets.scm
+++ b/languages/jsonnet/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)


### PR DESCRIPTION
Adding the 'brackets.scm' file to allow jumping between each bracket type.

Inspired by https://github.com/zed-industries/zed/blob/main/crates/languages/src/json/brackets.scm

Tested and works on 0.167.2 on a mac