### PR TITLE
Add basic outline support

### DIFF
--- a/languages/jsonnet/outline.scm
+++ b/languages/jsonnet/outline.scm
@@ -1,0 +1,9 @@
+(local_bind
+  (local) @context
+  (bind (id) @name)
+) @item
+
+(
+  field
+  (fieldname) @name
+) @item


### PR DESCRIPTION
Hi! This pull request adds basic support for the outline view that shows symbols in jsonnet file.

Simple jsonnet file:

```jsonnet
local my_function(x, y=10) = x + y;

local multiline_function(x) =
  local temp = x * 2;
  [temp, temp + 1];

local object = {
  my_method(x): x * x,
};

{
  call_inline_function:
    (function(x) x * x)(5),

  call_multiline_function: multiline_function(4),

  call: my_function(true),

  named_params: my_function(x=2),
  named_params2: my_function(y=3, x=2),

  call_method1: object.my_method(3),

  standard_lib:
    std.join(' ', std.split('foo/bar', '/')),

  len: [
    std.length('hello'),
    std.length([1, 2, 3]),
  ],
}

```

|before|after|
|--------|----------|
| ![CleanShot 2025-05-31 at 14 00 10@2x](https://github.com/user-attachments/assets/2541e0c9-b401-450a-8866-dfa6a715dd60)| ![CleanShot 2025-05-31 at 14 00 58@2x](https://github.com/user-attachments/assets/0aa395fc-d5e1-445c-a1e9-e497281a3b3b)|

I found only one problem. In the outline view, you can see that the whole hierarchy is displayed as a tree. This happens because the `local ...` statement (`local_bind`) captures everything until the end of the file. This is probably related to the tree-sitter grammar for jsonnet, so I need to open an issue there.

Thanks!